### PR TITLE
Apply card images and CSS tweaks

### DIFF
--- a/css/dinogamev2.css
+++ b/css/dinogamev2.css
@@ -10,7 +10,7 @@ body {
 	font-family: montserrat light;	
 }
 #gameStats{
-	background: #001711;
+	background: black;
 	width: 1175px;
 	margin: 20px auto 20px;
 	display: block;
@@ -49,7 +49,7 @@ body {
 }
 
 #game {
-	background: #001711;
+	background: black;
 	width: 1155px;
 	height: 600px;
 	margin: 0 auto;
@@ -122,8 +122,8 @@ body {
 	border-radius: 5px;
 	display: block;
 	font-size: 30px;
-	margin: 50px auto 0;
-	padding: 100px;
+	margin: 100px auto 0;
+	padding: 10px;
 	width: 150px;
 	border: 5px solid #000;
 	color:#000;
@@ -149,6 +149,9 @@ body {
 	-webkit-transition-duration: .3s;
 	-webkit-backface-visibility: hidden;
 	-moz-backface-visibility: hidden;
+	-moz-border-radius: 20px;
+	-webkit-border-radius: 20px;
+	border-radius: 20px;
 }
 
 .front {
@@ -161,7 +164,7 @@ body {
 	z-index: 10;
 }
 .back {
-	background: #efefef url(../images/deck.png);
+	background-size: 100% 100%;
 	-webkit-transform-style: preserve-3d; 
     -moz-transform-style: preserve-3d; /** fixes non transitive 3d from parent and child **/
     transform-style: preserve-3d;
@@ -171,8 +174,8 @@ body {
 	z-index: 8;
 }
 .card:hover .face, .card-flipped .face {
-	-webkit-box-shadow: 0 0 6px #aaa;
-	box-shadow: 0 0 6px #aaa;
+	-webkit-box-shadow: 0 0 15px #eee;
+	box-shadow: 0 0 15px #eee;
 }
 .card-flipped .front {
 	-webkit-transform-style: preserve-3d; 
@@ -195,16 +198,6 @@ body {
 .card-removed {
 	opacity: 0;
 }
-
-.blueDino {background-position: 0 0;}
-.brownDino {background-position: -110px 0;}
-.redDino {background-position: -220px 0;}
-.greenDino {background-position: -330px 0;}
-.purpDino {background-position: -440px 0;}
-.burgDino {background-position: -550px 0;}
-.orangeDino {background-position: -660px 0;}
-.purp2Dino {background-position: -770px 0;}
-.pinkDino {background-position: -880px 0;}
 
 
 #linkBack a.button {

--- a/js/dinopairsv3.js
+++ b/js/dinopairsv3.js
@@ -2,7 +2,19 @@ if(typeof zmr !== 'object'){
 	var zmr = {};
 }
 
-zmr.masterCardDeck = ['blueDino',  'blueDino', 'brownDino', 'brownDino', 'redDino', 'redDino', 'greenDino', 'greenDino', 'purpDino', 'purpDino'];
+// Build the list of cards, matching images in /images/cards. Since the
+// board can only fit 2 rows of 5, slice the unique list down to 5 cards (10 total).
+zmr.cardList = ['API', 'CMS', 'DCS', 'DiGS', 'DSC', 'OS', 'Responsive', 'SLA'].slice(0, 5);
+zmr.masterCardDeck = [];
+
+// Build the deck using the card list.
+// The cards are in pairs of Title & Definition
+// using this convention: name.png and name1.png.
+for (var i = 0; i < zmr.cardList.length; i++) {
+	var card = zmr.cardList[i];
+	zmr.masterCardDeck.push(card);
+	zmr.masterCardDeck.push(card + "1");
+}
 
 zmr.dinoGame = (function(jQ) {
 	var score;
@@ -61,11 +73,12 @@ zmr.dinoGame = (function(jQ) {
 									"left" : (jQ(this).width() + 20) * (index % 5),
 									"top" : (jQ(this).height() + 20) * Math.floor(index / 5)
 								});
-								// get a pattern from the shuffled deck
-								var pattern = cardDeck.pop();
+								// get an image/pattern from the shuffled deck
+								var imageName = cardDeck.pop();
+								var pattern = imageName.replace(/[0-9]/g, '');
 								
-								// visually apply the pattern on the card's back side.
-								jQ(this).find(".back").addClass(pattern);
+								// visually apply the card image on the card's back side.
+								jQ(this).find(".back").css("background-image", "url(images/cards/" + imageName + ".png)");
 								
 								// embed the pattern data into the DOM element.
 								jQ(this).attr("data-pattern",pattern);


### PR DESCRIPTION
I applied the new images to the cards. Looking good! There were more image pairs than could fit on the board, so it only shows the first 5 pairs. We could make the board bigger but then they might have to scroll, up to you!

**Other changes:**
- Fix square borders on card hover
- Adjust card hover glow
- Shrink and move "Play Again" button so it doesn't cover up the Congratulations text
- Set board/stats background to match Intro and Congrats images
- Remove unused CSS
